### PR TITLE
Restore auth token from the correct localStorage key (closes #34)

### DIFF
--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
-  token: localStorage.getItem("token"),
+  token: localStorage.getItem("smart-metrics-logbook"),
   isAuthenticated: null,
   loading: true,
   user: {},


### PR DESCRIPTION
Closes #34

`authSlice` read the token from `localStorage.getItem("token")`, but `setAuthToken` persists it under `"smart-metrics-logbook"`. The keys are now aligned so the session survives a page refresh.