### PR TITLE
Give metricsSlice a unique name (closes #35)

### DIFF
--- a/src/store/metricsSlice.js
+++ b/src/store/metricsSlice.js
@@ -9,7 +9,7 @@ const initialState = {
 };
 
 export const metricsSlice = createSlice({
-  name: "auth",
+  name: "metrics",
   initialState: initialState,
   reducers: {
     addMetric: (state, action) => {


### PR DESCRIPTION
Closes #35

`metricsSlice` was created with `name: "auth"`, colliding with the auth slice's action-type prefix. Renamed to `"metrics"`.