### PR TITLE
Guard axios interceptor against missing response (closes #36)

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -27,7 +27,7 @@ const api = axios.create({
 api.interceptors.response.use(
   (res) => res,
   (err) => {
-    if (err.response.status === 401) {
+    if (err.response?.status === 401) {
       store.dispatch(userLogOut());
     }
     return Promise.reject(err);


### PR DESCRIPTION
Closes #36

Network failures have no `err.response`, so `err.response.status` threw a `TypeError` and masked the real error. Now uses `err.response?.status`.