### PR TITLE
Add a CRA dev proxy to the backend (closes #39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "smart-metrics-logbook",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "engines": { "node": ">=16" },
   "dependencies": {
     "@emotion/react": "^11.10.6",


### PR DESCRIPTION
Closes #39

Adds a CRA `proxy` field so API calls during local development are forwarded to the backend on port 8000, avoiding hardcoded cross-origin URLs in dev.