### PR TITLE
Make the start script cross-platform (closes #40)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "apexcharts": "^3.37.1",
     "axios": "^1.3.4",
     "clsx": "^1.2.1",
+    "cross-env": "^7.0.3",
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.7",
     "formik": "^2.2.9",
@@ -48,7 +49,7 @@
     "yup": "^1.0.2"
   },
   "scripts": {
-    "start": "set port=3040 && react-scripts start",
+    "start": "cross-env PORT=3040 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Closes #40

Replaces the Windows-only `set port=3040` with `cross-env PORT=3040` so `npm start` works on every OS and CRA actually reads the port.