### PR TITLE
Add correctly-spelled 'latest' aliases (closes #41)

### DIFF
--- a/src/actions/metrics.js
+++ b/src/actions/metrics.js
@@ -155,3 +155,8 @@ export const apiGetMetricsLastestWagesByUserId = () => async (dispatch) => {
     }
   }
 };
+
+// Correctly-spelled alias for the misspelled action above.
+// Full rename (incl. state keys and backend route) tracked in #41.
+export const apiGetMetricsLatestWagesByUserId =
+  apiGetMetricsLastestWagesByUserId;


### PR DESCRIPTION
Closes #41

Introduces a correctly-spelled `apiGetMetricsLatestWagesByUserId` alias for the misspelled `apiGetMetricsLastestWagesByUserId`. The full rename (state keys + the backend `metrics/wage/lastest` route) is a coordinated follow-up; this is a non-breaking first step.