### PR TITLE
Disable auth submit buttons while pending (closes #43)

### DIFF
--- a/src/pages/auth/Login.js
+++ b/src/pages/auth/Login.js
@@ -29,8 +29,8 @@ const Login = ({ isAuthenticated, apiLogin }) => {
         .required("Email is required"),
       password: Yup.string().max(255).required("Password is required"),
     }),
-    onSubmit: (values) => {
-      apiLogin({
+    onSubmit: async (values) => {
+      await apiLogin({
         email: values.email,
         password: values.password,
       });
@@ -115,6 +115,7 @@ const Login = ({ isAuthenticated, apiLogin }) => {
                 </Typography>
               )}
               <Button
+                disabled={formik.isSubmitting}
                 fullWidth
                 size="large"
                 sx={{ mt: 3 }}

--- a/src/pages/auth/Register.js
+++ b/src/pages/auth/Register.js
@@ -33,8 +33,8 @@ const Register = ({ apiRegister, isAuthenticated }) => {
       name: Yup.string().max(255).required("Name is required"),
       password: Yup.string().max(255).required("Password is required"),
     }),
-    onSubmit: (values) => {
-      apiRegister({
+    onSubmit: async (values) => {
+      await apiRegister({
         name: values.name,
         email: values.email,
         password: values.password,
@@ -147,6 +147,7 @@ const Register = ({ apiRegister, isAuthenticated }) => {
                 </Typography>
               )}
               <Button
+                disabled={formik.isSubmitting}
                 fullWidth
                 size="large"
                 sx={{ mt: 3 }}


### PR DESCRIPTION
Closes #43

Makes the Login/Register `onSubmit` async and disables the submit button via Formik's `isSubmitting`, preventing duplicate submissions.