### PR TITLE
Only redirect to login on genuine auth failure (closes #44)

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -13,12 +13,12 @@ export const apiLoadUser = (navigate) => async (dispatch) => {
 
     await dispatch(userLogined(res.data.doc));
   } catch (err) {
-    navigate("/auth/login");
-    const errors = err?.response?.data?.errors;
-    if (errors) {
-      errors.forEach((error) => console.log(error.msg));
+    // Only force a logout/redirect on a genuine auth failure (401);
+    // transient/network errors should preserve the session.
+    if (err?.response?.status === 401) {
+      await dispatch(userAuthError());
+      navigate("/auth/login");
     }
-    await dispatch(userAuthError());
   }
 };
 


### PR DESCRIPTION
Closes #44

`apiLoadUser` previously redirected to `/auth/login` on any error. Now it only logs the user out / redirects on a 401, preserving the session through transient/network errors.