### PR TITLE
Reset auth state fully in userAuthError (closes #45)

### DIFF
--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -30,8 +30,11 @@ export const authReducer = createSlice({
       state.loading = false;
       state.user = null;
     },
-    userAuthError: (state, action) => {
+    userAuthError: (state) => {
       state.token = null;
+      state.isAuthenticated = false;
+      state.loading = false;
+      state.user = null;
     },
   },
 });


### PR DESCRIPTION
Closes #45

`userAuthError` only cleared the token, leaving `isAuthenticated` stale. It now mirrors `userLogOut` and resets the auth state.