### PR TITLE
Make apiLogout a thunk that clears the token (closes #46)

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -58,4 +58,7 @@ export const apiLogin = (formData) => async (dispatch) => {
 };
 
 // Logout
-export const apiLogout = () => userLogOut();
+export const apiLogout = () => (dispatch) => {
+  setAuthToken(null);
+  dispatch(userLogOut());
+};


### PR DESCRIPTION
Closes #46

`apiLogout` is now a thunk that clears the persisted token and axios header via `setAuthToken(null)` and dispatches `userLogOut`, matching the rest of the action layer.