### PR TITLE
Simplify PrivateRoute to hooks only (closes #47)

### DIFF
--- a/src/components/routing/PrivateRoute.js
+++ b/src/components/routing/PrivateRoute.js
@@ -1,24 +1,15 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
-import PropTypes from "prop-types";
-import { connect, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import CirclesLoader from "../loader/CirclesLoader";
 
 const PrivateRoute = ({ component: Component }) => {
   const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
   const loading = useSelector((state) => state.auth.loading);
+
   if (loading) return <CirclesLoader />;
   if (isAuthenticated) return <Component />;
-
   return <Navigate to="/auth/login" />;
 };
 
-PrivateRoute.propTypes = {
-  auth: PropTypes.object.isRequired,
-};
-
-const mapStateToProps = (state) => ({
-  auth: state.auth,
-});
-
-export default connect(mapStateToProps)(PrivateRoute);
+export default PrivateRoute;


### PR DESCRIPTION
Closes #47

Removes the redundant `connect`/`mapStateToProps` and the mismatched required `auth` propType, keeping the hook-based implementation.