### PR TITLE
Centralize token storage key and document XSS risk (closes #48)

### DIFF
--- a/src/utils/setAuthToken.js
+++ b/src/utils/setAuthToken.js
@@ -1,12 +1,18 @@
 import api from "./api";
 
+// Central key for the persisted auth token.
+// SECURITY NOTE: storing JWTs in localStorage exposes them to any XSS on the
+// page. Prefer an httpOnly cookie set by the backend; until then keep CSP tight
+// and sanitize all rendered user input. Tracked in issue #48.
+export const STORAGE_KEY = "smart-metrics-logbook";
+
 const setAuthToken = (token) => {
   if (token) {
     api.defaults.headers.common["x-auth-token"] = token;
-    localStorage.setItem("smart-metrics-logbook", token);
+    localStorage.setItem(STORAGE_KEY, token);
   } else {
-    delete api.defaults.headers["x-auth-token"];
-    localStorage.removeItem("smart-metrics-logbook");
+    delete api.defaults.headers.common["x-auth-token"];
+    localStorage.removeItem(STORAGE_KEY);
   }
 };
 


### PR DESCRIPTION
Closes #48

Extracts the localStorage key into a single `STORAGE_KEY` constant and documents the XSS exposure of storing JWTs in localStorage (with the httpOnly-cookie recommendation). Also fixes the header-removal path.