### PR TITLE
Drop direct 'moment' dep in favor of moment-timezone (closes #49)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.7",
     "formik": "^2.2.9",
-    "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",
     "notistack": "^3.0.1",
     "nprogress": "^0.2.0",

--- a/src/pages/Dashboard/BloodPressureChart.js
+++ b/src/pages/Dashboard/BloodPressureChart.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useSelector } from "react-redux";
 import ReactApexChart from "react-apexcharts";
-import moment from "moment";
+import moment from "moment-timezone";
 const BloodChart = ({
   data,
   filterStartDay,

--- a/src/pages/Dashboard/GroupChart.js
+++ b/src/pages/Dashboard/GroupChart.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Chart from "react-apexcharts";
 import { useSelector } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 
 export default function GroupChart({
   filterStartDay,

--- a/src/pages/Dashboard/TableForTextMetrics.js
+++ b/src/pages/Dashboard/TableForTextMetrics.js
@@ -7,7 +7,7 @@ import {
   TableContainer,
   Box,
 } from "@mui/material";
-import moment from "moment";
+import moment from "moment-timezone";
 import React from "react";
 
 const TableForTextMetrics = ({

--- a/src/pages/TotalMetricsValues/TotalMetricsValues.js
+++ b/src/pages/TotalMetricsValues/TotalMetricsValues.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import moment from "moment";
+import moment from "moment-timezone";
 import {
   Box,
   Container,

--- a/src/pages/Track/Track.js
+++ b/src/pages/Track/Track.js
@@ -1,5 +1,5 @@
 import React from "react";
-import moment from "moment";
+import moment from "moment-timezone";
 import {
   Box,
   Table,


### PR DESCRIPTION
Closes #49

All four date libraries are in use, so as a safe first consolidation step this removes the direct `moment` dependency and points its imports at `moment-timezone` (which is API-compatible and already a dependency). Further consolidation onto a single library is a follow-up.