### PR TITLE
Remove deprecated redux-devtools-extension dependency (closes #51)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-scripts": "5.0.1",
     "react-toastify": "^9.1.1",
     "recharts": "^2.5.0",
-    "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.4.2",
     "sass": "^1.58.3",
     "simplebar-react": "^3.2.1",


### PR DESCRIPTION
Closes #51

`redux-devtools-extension` is deprecated and unused (Redux Toolkit's `configureStore` wires devtools automatically in development). Removed from dependencies.