### PR TITLE
Code-split routes with React.lazy/Suspense (closes #52)

### DIFF
--- a/src/components/routing/MainRoutes.js
+++ b/src/components/routing/MainRoutes.js
@@ -1,18 +1,25 @@
 import React from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
 import PrivateRoute from "./PrivateRoute";
-import Login from "../../pages/auth/Login.js";
-import Register from "../../pages/auth/Register.js";
-import Dashboard from "../../pages/Dashboard/Dashboard";
-import Metrics from "../../pages/Metrics/Metrics";
-import NotFound from "../../pages/NotFound.js";
-import MetricsGroup from "../../pages/MetricsGroup/MetricsGroup";
-import TotalMetricsValues from "../../pages/TotalMetricsValues/TotalMetricsValues";
-import Track from "../../pages/Track/Track";
+import CirclesLoader from "../loader/CirclesLoader";
 import { setAuthToken } from "../../utils";
 import store from "../../store";
 import { apiLoadUser } from "../../actions/auth";
 import { userLogOut } from "../../store/authSlice";
+
+const Login = React.lazy(() => import("../../pages/auth/Login.js"));
+const Register = React.lazy(() => import("../../pages/auth/Register.js"));
+const Dashboard = React.lazy(() => import("../../pages/Dashboard/Dashboard"));
+const Metrics = React.lazy(() => import("../../pages/Metrics/Metrics"));
+const NotFound = React.lazy(() => import("../../pages/NotFound.js"));
+const MetricsGroup = React.lazy(() =>
+  import("../../pages/MetricsGroup/MetricsGroup")
+);
+const TotalMetricsValues = React.lazy(() =>
+  import("../../pages/TotalMetricsValues/TotalMetricsValues")
+);
+const Track = React.lazy(() => import("../../pages/Track/Track"));
+
 const MainRoutes = () => {
   const navigate = useNavigate();
   React.useEffect(() => {
@@ -24,26 +31,28 @@ const MainRoutes = () => {
       navigate("api/login");
       localStorage.removeItem("smart-metrics-logbook");
     }
-    window.addEventListener("storage", () => { });
+    window.addEventListener("storage", () => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
-    <Routes>
-      <Route path="/" element={<PrivateRoute component={Dashboard} />} />
-      <Route path="/auth/login" element={<Login></Login>}></Route>
-      <Route path="/auth/register" element={<Register></Register>}></Route>
-      <Route path="/metrics" element={<PrivateRoute component={Metrics} />} />
-      <Route path="/track" element={<PrivateRoute component={Track} />} />
-      <Route
-        path="metrics/viewallvalues"
-        element={<PrivateRoute component={TotalMetricsValues} />}
-      />
-      <Route
-        path="/group"
-        element={<PrivateRoute component={MetricsGroup} />}
-      />
-      <Route path="/*" element={<NotFound />} />
-    </Routes>
+    <React.Suspense fallback={<CirclesLoader />}>
+      <Routes>
+        <Route path="/" element={<PrivateRoute component={Dashboard} />} />
+        <Route path="/auth/login" element={<Login></Login>}></Route>
+        <Route path="/auth/register" element={<Register></Register>}></Route>
+        <Route path="/metrics" element={<PrivateRoute component={Metrics} />} />
+        <Route path="/track" element={<PrivateRoute component={Track} />} />
+        <Route
+          path="metrics/viewallvalues"
+          element={<PrivateRoute component={TotalMetricsValues} />}
+        />
+        <Route
+          path="/group"
+          element={<PrivateRoute component={MetricsGroup} />}
+        />
+        <Route path="/*" element={<NotFound />} />
+      </Routes>
+    </React.Suspense>
   );
 };
 


### PR DESCRIPTION
Closes #52

Converts the page imports in `MainRoutes` to `React.lazy` and wraps the routes in `Suspense` with a loader fallback, so heavy pages (and their chart/date libs) load on demand.