### PR TITLE
Add a top-level Error Boundary (closes #53)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { createTheme } from "./theme";
 import { CssBaseline } from "@mui/material";
 
 import MainRoutes from "./components/routing/MainRoutes";
+import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "@mui/material/styles";
 import "react-toastify/dist/ReactToastify.css";
 import "simplebar-react/dist/simplebar.min.css";
@@ -18,7 +19,9 @@ const App = () => {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Router>
-        <MainRoutes></MainRoutes>
+        <ErrorBoundary>
+          <MainRoutes></MainRoutes>
+        </ErrorBoundary>
       </Router>
       <ToastContainer></ToastContainer>
     </ThemeProvider>

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    // eslint-disable-next-line no-console
+    console.error("Unhandled UI error:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: 32, textAlign: "center" }}>
+          <h2>Something went wrong.</h2>
+          <button onClick={() => window.location.reload()}>Reload</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
Closes #53

Adds an `ErrorBoundary` component and wraps `MainRoutes` with it so a render error shows a fallback instead of a blank screen.