### PR TITLE
Surface metrics errors in state (closes #55)

### DIFF
--- a/src/store/metricsSlice.js
+++ b/src/store/metricsSlice.js
@@ -3,6 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
   metrics: [],
   loading: true,
+  error: null,
   wages: [],
   todayWages: [],
   lastestWages: [],
@@ -77,8 +78,9 @@ export const metricsSlice = createSlice({
         wage._id === action.payload._id ? action.payload : wage
       );
     },
-    metricsError: (state) => {
+    metricsError: (state, action) => {
       state.loading = false;
+      state.error = action.payload || "Something went wrong";
     },
   },
 });


### PR DESCRIPTION
Closes #55

Adds an `error` field to the metrics state and populates it in the `metricsError` reducer so failures can be rendered, not just toasted.