### PR TITLE
Add accessible names to the auth forms (closes #59)

### DIFF
--- a/src/pages/auth/Login.js
+++ b/src/pages/auth/Login.js
@@ -75,7 +75,7 @@ const Login = ({ isAuthenticated, apiLogin }) => {
                 </Link>
               </Typography>
             </Stack>
-            <form noValidate onSubmit={formik.handleSubmit}>
+            <form noValidate aria-label="Login form" onSubmit={formik.handleSubmit}>
               <Stack spacing={3}>
                 <TextField
                   error={!!(formik.touched.email && formik.errors.email)}

--- a/src/pages/auth/Register.js
+++ b/src/pages/auth/Register.js
@@ -79,7 +79,7 @@ const Register = ({ apiRegister, isAuthenticated }) => {
                 </Link>
               </Typography>
             </Stack>
-            <form noValidate onSubmit={formik.handleSubmit}>
+            <form noValidate aria-label="Registration form" onSubmit={formik.handleSubmit}>
               <Stack spacing={3}>
                 <TextField
                   error={!!(formik.touched.name && formik.errors.name)}


### PR DESCRIPTION
Closes #59

First accessibility pass: gives the Login and Register forms accessible names. A broader audit (icon buttons, dialogs, chart alternatives) is a follow-up.