### PR TITLE
Guard addMetricWage against unloaded lists (closes #61)

### DIFF
--- a/src/store/metricsSlice.js
+++ b/src/store/metricsSlice.js
@@ -41,10 +41,12 @@ export const metricsSlice = createSlice({
     },
 
     addMetricWage: (state, action) => {
-      state.wages = [...state.wages, action.payload];
-      state.todayWages = [...state.todayWages, action.payload];
+      if (!action.payload) return;
+      state.wages = [...(state.wages || []), action.payload];
+      state.todayWages = [...(state.todayWages || []), action.payload];
+      state.lastestWages = state.lastestWages || [];
       state.lastestWages.unshift(action.payload);
-      state.lastestWages.length > 3 && state.lastestWages.pop();
+      if (state.lastestWages.length > 3) state.lastestWages.pop();
     },
 
     getMetricsAllWages: (state, action) => {


### PR DESCRIPTION
Closes #61

Makes `addMetricWage` null-safe so it doesn't assume `wages`/`todayWages`/`lastestWages` are already populated, and ignores empty payloads.