### PR TITLE
Pin pre-release MUI deps and add engines (closes #63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "smart-metrics-logbook",
   "version": "0.1.0",
   "private": true,
+  "engines": { "node": ">=16" },
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
@@ -12,7 +13,7 @@
     "@mui/material": "^5.11.12",
     "@mui/styles": "^5.11.13",
     "@mui/system": "^5.11.12",
-    "@mui/x-date-pickers": "^6.0.0-beta.5",
+    "@mui/x-date-pickers": "^6.18.0",
     "@reduxjs/toolkit": "^1.9.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
Closes #63

Moves `@mui/x-date-pickers` off the `6.0.0-beta` channel to stable `^6.18.0` and adds an `engines` field for reproducible installs. Run `npm audit` as a follow-up.